### PR TITLE
Open default folder

### DIFF
--- a/src/app/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -85,7 +85,7 @@ export class AddTorrentDialogComponent implements OnInit {
   /** Handle opening file explorer dialog & handling any callbacks */
   public openFileSystemExplorerDialog(event: any): void {
     this.fileSystemExplorerDialogREF = this.fileSystemDialog.open(FileSystemDialogComponent,
-      {minWidth: "50%", panelClass: "generic-dialog", autoFocus: false});
+      {minWidth: "50%", panelClass: "generic-dialog", autoFocus: false, data: { initialFilePath: this.filesDestination }});
 
     this.fileSystemExplorerDialogREF.afterClosed().subscribe((res: string) => {
       // If use confirmed choice of file path

--- a/src/app/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -90,7 +90,7 @@ export class AddTorrentDialogComponent implements OnInit {
     this.fileSystemExplorerDialogREF.afterClosed().subscribe((res: string) => {
       // If use confirmed choice of file path
       if(res) {
-        this.filesDestination = res + this.fs_service.getFileSystemDelimeter();
+        this.filesDestination = res
       }
     })
   }

--- a/src/app/delete-torrent-dialog/delete-torrent-dialog.component.ts
+++ b/src/app/delete-torrent-dialog/delete-torrent-dialog.component.ts
@@ -24,8 +24,8 @@ export class DeleteTorrentDialogComponent implements OnInit {
   private attemptedDelete = false;  // Keep track of whether any deletes were attempted
   public isDarkTheme: Observable<boolean>;
 
-  constructor(private dialogRef:MatDialogRef<DeleteTorrentDialogComponent>, private TorrentService: TorrentDataHTTPService, @Inject(MAT_DIALOG_DATA) data, 
-              private theme: ThemeService) { 
+  constructor(private dialogRef:MatDialogRef<DeleteTorrentDialogComponent>, private TorrentService: TorrentDataHTTPService, @Inject(MAT_DIALOG_DATA) data,
+              private theme: ThemeService) {
     this.torrentsToDelete = data.torrent;
    }
 
@@ -51,7 +51,7 @@ export class DeleteTorrentDialogComponent implements OnInit {
       console.log(res);
       this.finishCallback(res);
 
-    }, 
+    },
     (error: any) => {
       console.error(error);
       this.finishCallback(error);

--- a/src/app/file-system-dialog/file-system-dialog.component.html
+++ b/src/app/file-system-dialog/file-system-dialog.component.html
@@ -67,7 +67,7 @@
 
         <br/>
         <br/>
-        <h3 id="saveLocation"><b>Save Location: </b>{{getFilePath()}}</h3>
+        <h3 id="saveLocation"><b>Save Location: </b>{{getFilePath() === "" ? "{ Unchanged }" : getFilePath()}}</h3>
 
     </mat-dialog-content>
     <mat-dialog-actions align="end">

--- a/src/app/file-system-dialog/file-system-dialog.component.ts
+++ b/src/app/file-system-dialog/file-system-dialog.component.ts
@@ -6,7 +6,7 @@ import { ThemeService } from '../services/theme.service';
 import { Observable } from 'rxjs';
 import Inode from '../services/file-system/FileSystemNodes/Inode';
 import { FileSystemService } from '../services/file-system/file-system.service';
-import { DirectoryNotFoundError } from '../services/file-system/Exceptions/FileSystemExceptions';
+import { DirectoryNotFoundError, InvalidNameError } from '../services/file-system/Exceptions/FileSystemExceptions';
 import DirectoryNode from '../services/file-system/FileSystemNodes/DirectoryNode';
 import FileNode from '../services/file-system/FileSystemNodes/FileNode';
 
@@ -103,7 +103,20 @@ export class FileSystemDialogComponent implements OnInit {
       return;
     }
 
-    if (this.selectedDir != null) { this.selectedDir.addChild(name); }
+    // Attempt to add this new folder
+    if (this.selectedDir != null) {
+      try {
+        this.selectedDir.addChild(name);
+      } catch (error) {
+        if(error instanceof InvalidNameError) {
+          alert(error.message);
+          return;   // Let user try again without closing folder creation input
+        } else {
+          throw error;
+        }
+      }
+
+    }
     else { alert("Can't create a directory at the root!"); }
 
     this.cancelFolderCreation();

--- a/src/app/file-system-dialog/file-system-dialog.component.ts
+++ b/src/app/file-system-dialog/file-system-dialog.component.ts
@@ -1,11 +1,14 @@
-import { Component, OnInit } from '@angular/core';
-import { MatDialogRef } from '@angular/material/dialog';
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { FileDirectoryExplorerService } from '../services/file-system/file-directory-explorer.service';
 import TreeNode from '../services/file-system/TreeNode';
 import { ThemeService } from '../services/theme.service';
 import { Observable } from 'rxjs';
 import Inode from '../services/file-system/FileSystemNodes/Inode';
 import { FileSystemService } from '../services/file-system/file-system.service';
+import { DirectoryNotFoundError } from '../services/file-system/Exceptions/FileSystemExceptions';
+import DirectoryNode from '../services/file-system/FileSystemNodes/DirectoryNode';
+import FileNode from '../services/file-system/FileSystemNodes/FileNode';
 
 @Component({
   selector: 'app-file-system-dialog',
@@ -15,22 +18,27 @@ import { FileSystemService } from '../services/file-system/file-system.service';
 export class FileSystemDialogComponent implements OnInit {
 
   public filePath: string[] = [];
-  public leftChildren: Inode[] = [];              // Keep track of what folders to show in left nav
-  public rightChildren: Inode[] = [];
-  public selectedDir: Inode = null;               // Keep track of what folder the user last selected (i.e. what folder they're currently in)
+  public root: DirectoryNode;
+  public leftChildren: DirectoryNode[] = [];                 // Keep track of what folders to show in left nav
+  public rightChildren: (DirectoryNode | FileNode)[] = [];
+  public selectedDir: DirectoryNode = null;                  // Keep track of what folder the user last selected (i.e. what folder they're currently in)
   public isDarkTheme: Observable<boolean>;
   public isCreatingNewFolder: boolean = false;       // Keep track of when user wants to create a new folder
 
   private newDirValue: string = ""                   // Name of new folder to create
+  private inputData: any;                            // Data passed in to this component
 
   constructor(private dialogRef:MatDialogRef<FileSystemDialogComponent>, private fs: FileDirectoryExplorerService, private fs_service: FileSystemService,
-              private theme: ThemeService) { }
+              private theme: ThemeService, @Inject(MAT_DIALOG_DATA) inputData) { this.inputData = inputData; }
 
   ngOnInit(): void {
     this.isDarkTheme = this.theme.getThemeSubscription();
-    let root = this.fs.getFileSystem();
-    this.leftChildren = root.getChildren();
+    this.root = this.fs.getFileSystem();
+    this.leftChildren = this.root.getChildren() as DirectoryNode[];
     this.leftChildren.sort(TreeNode.sort());
+
+    this._openToInitialFolder();
+    console.log("file path", this.inputData.initialFilePath);
   }
 
   public closeDialog(): void {
@@ -43,7 +51,7 @@ export class FileSystemDialogComponent implements OnInit {
   }
 
   /** Go to chosen child directory */
-  public navigateToDir(dir: Inode, type: string): void {
+  public navigateToDir(dir: DirectoryNode, type: string): void {
 
     this.cancelFolderCreation();
 
@@ -53,16 +61,16 @@ export class FileSystemDialogComponent implements OnInit {
         this.filePath.pop();
       }
 
-      let dirChosen = Inode.GetChildFromChildrenList(this.leftChildren, dir);
+      let dirChosen = DirectoryNode.GetChildFromChildrenList(this.leftChildren, dir);
       this.rightChildren = dirChosen.getChildren();
 
       this.rightChildren.sort(TreeNode.sort());
     }
     else if(type === "child") {
 
-      this.leftChildren = this.rightChildren;
+      this.leftChildren = this.rightChildren as DirectoryNode[];
 
-      let dirChosen = Inode.GetChildFromChildrenList(this.rightChildren, dir);
+      let dirChosen = DirectoryNode.GetChildFromChildrenList(this.rightChildren, dir);
       this.rightChildren = dirChosen.getChildren();
       this.rightChildren.sort(TreeNode.sort());
     }
@@ -79,7 +87,7 @@ export class FileSystemDialogComponent implements OnInit {
     // If parent is not root, continue
     if(parent.getParent()) {
       this.rightChildren = this.leftChildren;
-      this.leftChildren = parent.getParent().getChildren();
+      this.leftChildren = parent.getParent().getChildren() as DirectoryNode[];
 
       this.leftChildren.sort(TreeNode.sort());
       this.rightChildren.sort(TreeNode.sort());
@@ -149,6 +157,29 @@ export class FileSystemDialogComponent implements OnInit {
   public getNumChildrenString(dir: Inode): string {
     let len = dir.getChildren().length
     return len < 1 ? `Empty` : len === 1 ? `1 subfolder` : `${len} subfolders`
+  }
+
+  /** Open the file system explorer to the initial folder passed in.
+   * If no such folder exists, we will open the root instead.
+   */
+  private _openToInitialFolder(): void {
+    let path = this.inputData.initialFilePath;
+    if (!path) { return; }
+
+    // Try opening file system to folder represented by the given path
+    try {
+      let new_root = FileSystemService.GetDirectoryByAbsolutePath(this.root, path, this.fs_service.getFileSystemDelimeter());
+      this.leftChildren = new_root.getParent().getChildren() as DirectoryNode[];
+      this.rightChildren = new_root.getChildren();
+      this.selectedDir = new_root;
+
+    } catch (error) {
+      if(error instanceof DirectoryNotFoundError) {
+        console.log("Couldn't open to folder:", path);
+      } else{
+        throw error;    /** Let all others bubble up */
+      }
+    }
   }
 
 }

--- a/src/app/file-system-dialog/file-system-dialog.component.ts
+++ b/src/app/file-system-dialog/file-system-dialog.component.ts
@@ -17,7 +17,6 @@ import FileNode from '../services/file-system/FileSystemNodes/FileNode';
 })
 export class FileSystemDialogComponent implements OnInit {
 
-  public filePath: string[] = [];
   public root: DirectoryNode;
   public leftChildren: DirectoryNode[] = [];                 // Keep track of what folders to show in left nav
   public rightChildren: (DirectoryNode | FileNode)[] = [];
@@ -42,8 +41,8 @@ export class FileSystemDialogComponent implements OnInit {
   }
 
   public closeDialog(): void {
-    if(this.filePath.length > 0) {
-      let fp = this.filePath.join(this.fs_service.getFileSystemDelimeter());
+    let fp = this.getFilePath()
+    if(fp.length > 0) {
       this.dialogRef.close(fp);
     } else {
       this.dialogRef.close();
@@ -57,9 +56,6 @@ export class FileSystemDialogComponent implements OnInit {
 
     // Refresh children shown in right panel
     if(type === "parent") {
-      if(this.rightChildren) {
-        this.filePath.pop();
-      }
 
       let dirChosen = DirectoryNode.GetChildFromChildrenList(this.leftChildren, dir);
       this.rightChildren = dirChosen.getChildren();
@@ -75,12 +71,10 @@ export class FileSystemDialogComponent implements OnInit {
       this.rightChildren.sort(TreeNode.sort());
     }
 
-    this.filePath.push(dir.getValue());
     this.selectedDir = dir;
   }
 
   public navigateUp(): void {
-    this.filePath.pop();
 
     let parent = this.leftChildren[0].getParent();
 
@@ -139,7 +133,7 @@ export class FileSystemDialogComponent implements OnInit {
   }
 
   public getFilePath(): string {
-    return this.filePath.length === 0 ? "{ Unchanged }" : this.filePath.join(this.fs_service.getFileSystemDelimeter());
+    return this.selectedDir ? this.selectedDir.getAbsolutePath(this.fs_service.getFileSystemDelimeter()) : "";
   }
 
   public isDirectorySelected(dir: Inode) {

--- a/src/app/file-system-tree-explorer/file-system-tree-explorer.component.ts
+++ b/src/app/file-system-tree-explorer/file-system-tree-explorer.component.ts
@@ -46,7 +46,7 @@ export class FileSystemTreeExplorerComponent implements OnChanges {
    */
   private async _updateData(): Promise<void> {
     let delimiter = "";
-    this.root = new DirectoryNode({value: ""});
+    this.root = new DirectoryNode({value: "", skipNameValidation: true});
 
     delimiter = this.directories.length === 0 ? "/" : FileSystemService.DetectFileDelimiter(this.directories[0].path);
 

--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -50,7 +50,7 @@
 #addTorrentButton {
     color: white;
     margin-right: 20px;
-    font-size: 13.5pt;
+    font-size: 13pt;
 }
 
 app-search-torrents {

--- a/src/app/services/file-system/Exceptions/FileSystemExceptions.ts
+++ b/src/app/services/file-system/Exceptions/FileSystemExceptions.ts
@@ -33,3 +33,10 @@ export class FileNotFoundError extends FileSystemError {
   }
 }
 
+export class InvalidNameError extends FileSystemError {
+  constructor(name: string, message?: string) {
+    super(message || `The file name '${name}' contains an invalid character.`);
+    this.name = "InvalidNameError";
+  }
+}
+

--- a/src/app/services/file-system/Exceptions/FileSystemExceptions.ts
+++ b/src/app/services/file-system/Exceptions/FileSystemExceptions.ts
@@ -19,3 +19,17 @@ export class FileNoChildrenError extends FileSystemError {
   }
 }
 
+export class DirectoryNotFoundError extends FileSystemError {
+  constructor(message?: string) {
+    super(message || "The directory with given path does not exist.");
+    this.name = "DirectoryNotFoundError";
+  }
+}
+
+export class FileNotFoundError extends FileSystemError {
+  constructor(message?: string) {
+    super(message || "The file with given path does not exist.");
+    this.name = "FileNotFoundError";
+  }
+}
+

--- a/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
+++ b/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
@@ -54,20 +54,6 @@ export default class DirectoryNode extends Inode implements SerializableNode {
     return super.getParent() as DirectoryNode;
   }
 
-  /** Get path to this node.
-   * Is calculated by combining value of all it's ancestors and itself, and
-   * joining by the file system delimiter.
-   *
-   * E.g. "C:/Users/user_1/Desktop"
-   * @returns A path that uniquely defines this directory.
-   */
-  public getAbsolutePath(delimiter: string): string {
-    if(this.parent) {
-      return this.parent.getAbsolutePath(delimiter) + this.value + delimiter;
-    }
-    return this.value
-  }
-
   /**
    * @override
    */

--- a/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
+++ b/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
@@ -6,6 +6,7 @@ import FileSystemType from '../Statics/FileSystemTypes';
 /** A class to represent a folder/directory.  */
 export default class DirectoryNode extends Inode implements SerializableNode {
   parent: DirectoryNode;
+  children: (DirectoryNode | FileNode)[];   // Children can be any combination of DirectoryNode and FileNode together
   type = FileSystemType.DirectoryNodeType;
 
   constructor(options: DirectoryNodeConstructor) {
@@ -27,10 +28,25 @@ export default class DirectoryNode extends Inode implements SerializableNode {
     return super.getChild(val) as DirectoryNode;
   }
 
+  /** Gets the subdirectory with given value. If not such directory exists,
+   * null is returned.
+   *
+   * @param val The value of the subdirectory to look for.
+   * @returns A directory representing the given value.
+   */
+  public getDirectory(val: any): DirectoryNode {
+    for(const child of this.children) {
+      if(child.value === val && child.type === FileSystemType.DirectoryNodeType) {
+        return child as DirectoryNode;
+      }
+    }
+    return null;
+  }
+
   /**
    * @override Need this to method overrided in order to resolve typescript errors
    */
-  public getChildren(): Inode[] {
+  public getChildren(): (DirectoryNode | FileNode)[] {
     return this.children;
   }
 
@@ -107,6 +123,10 @@ export default class DirectoryNode extends Inode implements SerializableNode {
     if(curr != null) {
       curr.setSize(curr.getSize() + (this.size - old_size));
     }
+  }
+
+  public static GetChildFromChildrenList(children: (DirectoryNode | FileNode)[], child: DirectoryNode): DirectoryNode {
+    return super.GetChildFromChildrenList(children, child) as DirectoryNode;
   }
 }
 

--- a/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
+++ b/src/app/services/file-system/FileSystemNodes/DirectoryNode.ts
@@ -54,6 +54,20 @@ export default class DirectoryNode extends Inode implements SerializableNode {
     return super.getParent() as DirectoryNode;
   }
 
+  /** Get path to this node.
+   * Is calculated by combining value of all it's ancestors and itself, and
+   * joining by the file system delimiter.
+   *
+   * E.g. "C:/Users/user_1/Desktop"
+   * @returns A path that uniquely defines this directory.
+   */
+  public getAbsolutePath(delimiter: string): string {
+    if(this.parent) {
+      return this.parent.getAbsolutePath(delimiter) + this.value + delimiter;
+    }
+    return this.value
+  }
+
   /**
    * @override
    */

--- a/src/app/services/file-system/FileSystemNodes/Inode.ts
+++ b/src/app/services/file-system/FileSystemNodes/Inode.ts
@@ -1,18 +1,24 @@
 import TreeNode, { TreeNodeConstructor } from "../TreeNode";
 import { SerializableNode } from 'src/utils/file-system/interfaces';
 import FileSystemType from '../Statics/FileSystemTypes';
+import { InvalidNameError } from '../Exceptions/FileSystemExceptions';
 
 /** A class to represent object in a File System. */
 export default class Inode extends TreeNode implements SerializableNode {
 
+  value: string;
   progress: number;
   children: Inode[];
   parent: Inode;
   size: number;
   type = FileSystemType.InodeType;
 
+  public static VALID_NAME_REGEX = /^[-\w^&'@{}[\],$=!#():.%+~ ]+$/;
+
   constructor(options: InodeConstructor) {
     super(options);
+
+    if(!options.skipNameValidation) { this.validateName(); }
 
     this.progress = options.progress || 1;              // Assume file is fully downloaded otherwise
     this.size = options.size || 0;
@@ -87,6 +93,21 @@ export default class Inode extends TreeNode implements SerializableNode {
     }
   }
 
+  /** Validate the name of a file/folder.
+   * If the name is invalid, an exception is thrown
+   * @param name The name of the file/folder
+   * @returns true iff the name is valid
+   * @throws InvalidNameError
+   */
+  public validateName(): boolean {
+    if(Inode.VALID_NAME_REGEX.test(this.value)) {
+      return true;
+    } else {
+      console.log("validation failed for:", this.value);
+      throw new InvalidNameError(this.value);
+    }
+  }
+
   public static GetChildFromChildrenList(children: Inode[], child: Inode): Inode {
     return super.GetChildFromChildrenList(children, child) as Inode;
   }
@@ -94,5 +115,9 @@ export default class Inode extends TreeNode implements SerializableNode {
 
 export interface InodeConstructor extends TreeNodeConstructor{
   children?: Inode[],
-  progress?: number
+  progress?: number,
+  /** Whether to skip name validation or not.
+   * DANGEROUS -- USE WITH CAUTION!
+   */
+  skipNameValidation?: boolean
 }

--- a/src/app/services/file-system/FileSystemNodes/Inode.ts
+++ b/src/app/services/file-system/FileSystemNodes/Inode.ts
@@ -50,6 +50,21 @@ export default class Inode extends TreeNode implements SerializableNode {
     return this.children;
   }
 
+  /** Get path to this file/directory.
+   * Is calculated by combining value of all it's ancestors and itself, and
+   * joining by the file system delimiter.
+   *
+   * E.g. "C:/Users/user_1/Desktop", "D:/Images/Ubuntu_LTS_1.iso", etc.
+   * @param delimiter The file delimiter to use when joining the path
+   * @returns A path that uniquely defines this file/directory.
+   */
+  public getAbsolutePath(delimiter: string): string {
+    if(this.parent) {
+      return this.parent.getAbsolutePath(delimiter) + this.value + delimiter;
+    }
+    return this.value
+  }
+
   public hasChildren(): boolean {
     return this.children && this.children.length > 0;
   }

--- a/src/app/services/file-system/file-system.service.ts
+++ b/src/app/services/file-system/file-system.service.ts
@@ -14,7 +14,7 @@ export class FileSystemService {
   private directoryDelimiter = config.filePathDelimeter  // How folders are split
 
   constructor() {
-    this.root = new DirectoryNode({value: ""});
+    this.root = new DirectoryNode({value: "", skipNameValidation: true});
   }
 
   public getFileSystem(): DirectoryNode {

--- a/src/app/services/file-system/file-system.service.ts
+++ b/src/app/services/file-system/file-system.service.ts
@@ -174,9 +174,8 @@ export class FileSystemService {
    * @throws DirectoryNotFoundError
    */
   public static GetDirectoryByAbsolutePath(root: DirectoryNode, path: string, delimiter: string): DirectoryNode {
-    debugger;
     let curr = root;
-    let dirs = path.split(delimiter);
+    let dirs = path.split(delimiter).filter(elem => {return !!elem});
 
     for(const dir of dirs) {
       if(!(curr = curr.getDirectory(dir))) {

--- a/src/app/services/file-system/file-system.service.ts
+++ b/src/app/services/file-system/file-system.service.ts
@@ -3,6 +3,7 @@ import * as config from '../../../assets/config.json';
 import DirectoryNode from './FileSystemNodes/DirectoryNode';
 import Inode from './FileSystemNodes/Inode';
 import FileNode from './FileSystemNodes/FileNode';
+import { DirectoryNotFoundError } from './Exceptions/FileSystemExceptions';
 
 @Injectable({
   providedIn: 'root'
@@ -161,6 +162,30 @@ export class FileSystemService {
     }
     console.log('using unix')
     return "/";
+  }
+
+  /** Given an absolute path (e.g. C:/Users/user_1/Desktop), get the
+   * directory node that represents it. If no such directory exists, null is returned.
+   *
+   * @param root The root of the file system
+   * @param path The path to the directory.
+   * @param delimiter The delimiter the file system uses
+   * @returns A directory that represents the given path.
+   * @throws DirectoryNotFoundError
+   */
+  public static GetDirectoryByAbsolutePath(root: DirectoryNode, path: string, delimiter: string): DirectoryNode {
+    debugger;
+    let curr = root;
+    let dirs = path.split(delimiter);
+
+    for(const dir of dirs) {
+      if(!(curr = curr.getDirectory(dir))) {
+        // If this child is not found
+        throw new DirectoryNotFoundError();
+      }
+    }
+
+    return curr;
   }
 
 }


### PR DESCRIPTION
Open to default folder when uploading a torrent. For example, if the "Download To..." field has "C:/Users/user_1/Downloads", then the file system explorer will attempt to open that directory. If the directory doesn't exist, the user will start at the root instead.

Also includes refactoring and other minor fixes.