### PR TITLE
Feature/#35 download torrents magnet

### DIFF
--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.css
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.css
@@ -6,6 +6,25 @@ mat-form-field {
     width: 80%;
 }
 
+mat-hint {
+  font-size: small;
+}
+
 #magnet_url_input {
   min-width: 100%;
+  min-height: 280px;
+}
+
+#torrentFileUpload {
+  display: none;
+}
+
+.upload_files {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+}
+
+.upload_files h4 {
+  margin-left: 10px;
 }

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.css
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.css
@@ -5,3 +5,7 @@
 mat-form-field {
     width: 80%;
 }
+
+#magnet_url_input {
+  min-width: 100%;
+}

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -1,15 +1,25 @@
 <div [ngClass]="{'dark-theme': isDarkTheme | async}" class="mat-dialog-inner-container mat-app-background">
 
-  <h2 mat-dialog-title>Upload Torrent</h2>
-  <mat-divider></mat-divider>
+  <h2 mat-dialog-title>Upload Torrents</h2>
   <mat-dialog-content class="mat-typography">
-    <br/>
-    <h3>Choose File</h3>
-    <input multiple type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
-    <br/>
-    <br/>
-    <br/>
+    <mat-tab-group mat-align-tabs="start" (selectedTabChange)="handleTabChange($event)">
+      <mat-tab label="File Upload">
+        <br/>
+        <h3>Choose File</h3>
+        <input multiple type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
+      </mat-tab>
 
+      <mat-tab label="Magnet URL">
+        <br/>
+        <mat-form-field id="magnet_url_input" appearance="outline">
+          <mat-label>List of URLs...</mat-label>
+          <textarea rows="15" value="{{urlsToUpload}}" name="savepath" type="text" id="savepath" (change)="updateURLsToUpload($event)" matInput></textarea>
+          <mat-hint align="start"><strong>Separate each URL with a new line</strong> </mat-hint>
+        </mat-form-field>
+      </mat-tab>
+    </mat-tab-group>
+
+    <br/>
 
     <h3>Save Location</h3>
     <p>Pick a location to save the files. If none is chosen, the default shown will be used instead.</p>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -5,20 +5,30 @@
     <mat-tab-group mat-align-tabs="start" (selectedTabChange)="handleTabChange($event)">
       <mat-tab label="File Upload">
         <br/>
-        <h3>Choose File</h3>
-        <input multiple type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
+
+        <div class="upload_files">
+          <button color="accent" mat-raised-button (click)="torrentFileUpload.click()">
+            <mat-icon>attach_file</mat-icon>
+            &nbsp; Choose Files
+          </button>
+
+          <h4>{{getFilesToUploadString()}}</h4>
+
+          <input multiple #torrentFileUpload type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
+        </div>
       </mat-tab>
 
       <mat-tab label="Magnet URL">
         <br/>
         <mat-form-field id="magnet_url_input" appearance="outline">
           <mat-label>List of URLs...</mat-label>
-          <textarea rows="15" value="{{urlsToUpload}}" name="savepath" type="text" id="savepath" (change)="updateURLsToUpload($event)" matInput></textarea>
-          <mat-hint align="start"><strong>Separate each URL with a new line</strong> </mat-hint>
+          <textarea rows="14" value="{{urlsToUpload}}" name="savepath" type="text" id="savepath" (change)="updateURLsToUpload($event)" matInput></textarea>
+          <mat-hint align="start">Separate each URL with a new line</mat-hint>
         </mat-form-field>
       </mat-tab>
     </mat-tab-group>
 
+    <br/>
     <br/>
 
     <h3>Save Location</h3>
@@ -38,7 +48,6 @@
       <mat-icon matSuffix>folder_open</mat-icon>
     </mat-form-field>
 
-    <br/>
     <br/>
 
   </mat-dialog-content>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -44,6 +44,6 @@
   </mat-dialog-content>
   <mat-dialog-actions align="end">
     <button disabled={{isLoading}} mat-button [mat-dialog-close]="true">Cancel</button>
-    <button disabled={{isUploadDisabled()}} mat-raised-button (click)="handleFileUpload()" color="primary" cdkFocusInitial>Upload</button>
+    <button disabled={{isUploadDisabled()}} mat-raised-button (click)="handleUpload()" color="primary" cdkFocusInitial>Upload</button>
   </mat-dialog-actions>
 </div>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -10,6 +10,7 @@ import { ThemeService } from '../../services/theme.service';
 import { Observable } from 'rxjs';
 import { FileSystemService } from '../../services/file-system/file-system.service';
 import { GetDefaultSaveLocation } from 'src/utils/Helpers';
+import { MatTabChangeEvent } from '@angular/material/tabs';
 
 @Component({
   selector: 'app-add-torrent-dialog',
@@ -19,10 +20,13 @@ import { GetDefaultSaveLocation } from 'src/utils/Helpers';
 export class AddTorrentDialogComponent implements OnInit {
 
   public filesToUpload: FileList[] = null;
+  public urlsToUpload = "";
   public filesDestination = "";
   public isLoading = false;
   public isDarkTheme: Observable<boolean>;
 
+  /** Keep track of the mat-tab the user is currently in. */
+  private currentTab: MatTabChangeEvent;
   private fileSystemExplorerDialogREF: MatDialogRef<FileSystemDialogComponent, any>;
 
   constructor(private dialogRef:MatDialogRef<AddTorrentDialogComponent>, private data_store: TorrentDataStoreService,
@@ -31,6 +35,27 @@ export class AddTorrentDialogComponent implements OnInit {
   ngOnInit(): void {
     this.isDarkTheme = this.theme.getThemeSubscription();
     this.updateDefaultSaveLocationFromDisk();
+  }
+
+  handleTabChange(event: MatTabChangeEvent) {
+    this.currentTab = event;
+    console.log(event);
+  }
+
+  /** Callback for all upload events. */
+  handleUpload() {
+    switch (this.currentTab.index) {
+      case 0:
+        this.handleFileUpload();
+        break;
+
+      case 1:
+        this.handleMagnetURLUpload();
+        break;
+
+      default:
+        break;
+    }
   }
 
   /** Send request to server with all torrents uploaded. */
@@ -46,6 +71,11 @@ export class AddTorrentDialogComponent implements OnInit {
     });
   }
 
+  /** Upload the link to a magnet URL */
+  handleMagnetURLUpload(): void {
+
+  }
+
   /** Update which torrents the user wants to upload. */
   updateFiles(event: any): void {
     this.filesToUpload = event.target.files;
@@ -54,6 +84,11 @@ export class AddTorrentDialogComponent implements OnInit {
 
   /** Whether the Upload button should be disabled or not */
   isUploadDisabled(): boolean {
+    let destinationEmpty = this.filesDestination.trim() === "";
+    let urlToUploadEmpty = this.urlsToUpload.trim() === "";
+
+    // If user in magnet url tab, check if urls and file destination is empty
+    if(this.currentTab && this.currentTab.index === 1) { return destinationEmpty || urlToUploadEmpty; }
     return (this.isLoading || !this.filesToUpload || (this.filesToUpload.length === 0));
   }
 
@@ -65,6 +100,11 @@ export class AddTorrentDialogComponent implements OnInit {
   /** Callback for when user changes save location */
   public updateFileDestination(event: any): void {
     this.filesDestination = event.target.value;
+  }
+
+  /** Callback for when user modifies magnet urls */
+  updateURLsToUpload(event: any) {
+    this.urlsToUpload = event.target.value;
   }
 
   /** Handle cleanup for when adding torrents is completed

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -114,7 +114,7 @@ export class AddTorrentDialogComponent implements OnInit {
   }
 
   /** Callback for when user modifies magnet urls */
-  updateURLsToUpload(event: any) {
+  public updateURLsToUpload(event: any) {
     this.urlsToUpload = event.target.value;
   }
 
@@ -124,6 +124,11 @@ export class AddTorrentDialogComponent implements OnInit {
   private uploadCompletionCallback(): void {
     this.isLoading = false;
     this.dialogRef.close();
+  }
+
+  public getFilesToUploadString(): string {
+    let len = this.filesToUpload ? this.filesToUpload.length : 0;
+    return len === 1 ? `${len} file` : `${len} files`;
   }
 
   /** Handle opening file explorer dialog & handling any callbacks */

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -43,36 +43,47 @@ export class AddTorrentDialogComponent implements OnInit {
   }
 
   /** Callback for all upload events. */
-  handleUpload() {
-    switch (this.currentTab.index) {
+  async handleUpload() {
+    let index = this.currentTab ? this.currentTab.index : 0;  // User always starts at first tab
+    switch (index) {
       case 0:
-        this.handleFileUpload();
+        await this.handleFileUpload();
         break;
 
       case 1:
-        this.handleMagnetURLUpload();
+        await this.handleMagnetURLUpload();
         break;
 
       default:
         break;
     }
+    this.uploadCompletionCallback();
   }
 
   /** Send request to server with all torrents uploaded. */
-  handleFileUpload(): void {
+  async handleFileUpload(): Promise<void> {
     this.isLoading = true;
-    this.data_store.UploadTorrents(this.filesToUpload, this.filesDestination)
-    .then((resp: any) => {
-      this.uploadFileCompletionCallback(resp);
 
-    },
-    (error: any) => {
-      this.uploadFileCompletionCallback(error);
-    });
+    try {
+      let resp = await this.data_store.UploadTorrents(this.filesToUpload, this.filesDestination);
+      console.log('uploaded files', resp);
+
+    } catch (error) {
+      console.error('unable to upload files', error);
+    }
   }
 
   /** Upload the link to a magnet URL */
-  handleMagnetURLUpload(): void {
+  async handleMagnetURLUpload(): Promise<void> {
+    let urls = this.urlsToUpload.trim();
+
+    try {
+      let res = await this.data_store.UploadTorrentsFromMagnetURLs(urls, this.filesDestination).toPromise();
+      console.log('uploaded magnet urls', res);
+
+    } catch (error) {
+      console.error('uploaded magnet URLs!', error);
+    }
 
   }
 
@@ -110,9 +121,9 @@ export class AddTorrentDialogComponent implements OnInit {
   /** Handle cleanup for when adding torrents is completed
    * @param data Anything you want to send back to parent of this modal
    */
-  private uploadFileCompletionCallback(data: any): void {
+  private uploadCompletionCallback(): void {
     this.isLoading = false;
-    this.dialogRef.close(data);
+    this.dialogRef.close();
   }
 
   /** Handle opening file explorer dialog & handling any callbacks */

--- a/src/app/services/torrent-management/torrent-data-http.service.ts
+++ b/src/app/services/torrent-management/torrent-data-http.service.ts
@@ -46,6 +46,18 @@ export class TorrentDataHTTPService {
     return result;
   }
 
+  UploadNewTorrentsFromMagnetURLs(magnetURLs: string, destination: string): Observable<any> {
+    let root = this.http_endpoints.root;
+    let endpoint = this.http_endpoints.uploadTorrents;
+    let url = root + endpoint;
+
+    let body = new FormData();
+    body.append('savepath', destination);
+    body.append('urls', magnetURLs);
+
+    return this.sendTorrentHashesPOST(url, null, null, body);
+  }
+
   MoveTorrents(hashes: string[], destination: string): Observable<any> {
     let root = this.http_endpoints.root;
     let endpoint = this.http_endpoints.moveTorrents;

--- a/src/app/services/torrent-management/torrent-data-store.service.ts
+++ b/src/app/services/torrent-management/torrent-data-store.service.ts
@@ -58,6 +58,10 @@ export class TorrentDataStoreService {
     return await this.torrent_http_service.UploadNewTorrents(files, destination)
   }
 
+  public UploadTorrentsFromMagnetURLs(urls: string, destination: string): Observable<any> {
+    return this.torrent_http_service.UploadNewTorrentsFromMagnetURLs(urls, destination);
+  }
+
   public MoveTorrents(torrents: Torrent[], destination: string): Observable<any> {
     return this.torrent_http_service.MoveTorrents(torrents.map(elem => elem.hash), destination);
   }

--- a/src/app/services/torrent-management/torrent-data-store.service.ts
+++ b/src/app/services/torrent-management/torrent-data-store.service.ts
@@ -9,6 +9,7 @@ import { Observable, BehaviorSubject } from 'rxjs';
 export class TorrentDataStoreService {
 
   private rawData: any;
+  private rid = 0;
   private _torrentMainDataSource = new BehaviorSubject<MainData>(null);
 
   private TorrentMainData: MainData;
@@ -19,8 +20,8 @@ export class TorrentDataStoreService {
   /** Get torrent all torrent data and information
    * @param rid The RID value to send to server, for changelog purposes.
    */
-  public async GetTorrentData(rid: number): Promise<MainData> {
-    let data = await this.torrent_http_service.GetAllTorrentData(rid).toPromise();
+  public async GetTorrentData(rid?: number): Promise<MainData> {
+    let data = await this.torrent_http_service.GetAllTorrentData(rid || this.rid).toPromise();
 
     // Only set raw data initially
     if(!this.rawData){
@@ -31,6 +32,8 @@ export class TorrentDataStoreService {
     // TODO: When a torrent gets removed, we need to refresh our data
     this.setFormattedResponse(data);
     this._updateDataSource(this.TorrentMainData);
+
+    this.rid = data.rid;
 
     return this.TorrentMainData;
   }
@@ -185,5 +188,6 @@ export class TorrentDataStoreService {
   public ResetAllData(): void {
     this.rawData = null;
     this.TorrentMainData = null;
+    this.rid = 0;
   }
 }

--- a/src/app/torrents-table/torrents-table.component.ts
+++ b/src/app/torrents-table/torrents-table.component.ts
@@ -48,7 +48,6 @@ export class TorrentsTableComponent implements OnInit {
   private DEFAULT_REFRESH_TIMEOUT: number;
   private REFRESH_INTERVAL: any = null;
   private isFetchingData: boolean = false;
-  private RID = 0;
   private deleteTorDialogRef: MatDialogRef<DeleteTorrentDialogComponent, any>;
   private infoTorDialogRef: MatDialogRef<TorrentInfoDialogComponent, any>;
   private currentMatSort = {active: "Completed_On", direction: "desc"};
@@ -151,14 +150,13 @@ export class TorrentsTableComponent implements OnInit {
     }
 
     this.isFetchingData = true;
-    let data = await this.data_store.GetTorrentData(this.RID);
+    let data = await this.data_store.GetTorrentData();
 
     // Update state with fresh torrent data
     this.allTorrentInformation = data;
     this.allTorrentData = data.torrents;
     this.filteredTorrentData = data.torrents;
     this.isFetchingData = false;
-    this.RID += 1;
 
     // Re-sort data
     this.onMatSortChange(this.currentMatSort);
@@ -451,7 +449,6 @@ export class TorrentsTableComponent implements OnInit {
     this.allTorrentInformation = null;
     this.allTorrentData = null;
     this.filteredTorrentData = null;
-    this.RID = 0;
 
     this.data_store.ResetAllData();
     this.ClearTorrentRefreshInterval();


### PR DESCRIPTION
Enables a new tab in Upload Torrents modal: Magnet URL. Should be able to enter any valid magnet URLs supported by qbittorrent (each separated by a new line).

Also includes a quick fix for the "Choose Files" button not having any styling.

Fixes #34, resolves #35.