### PR TITLE
Feature/drag and drop upload

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -63,6 +63,7 @@ import { SuccessSnackbarComponent } from './services/notifications/snackbar/succ
 import { WarnSnackbarComponent } from './services/notifications/snackbar/warn-snackbar/warn-snackbar.component';
 import { ErrorSnackbarComponent } from './services/notifications/snackbar/error-snackbar/error-snackbar.component';
 import { InfoSnackbarComponent } from './services/notifications/snackbar/info-snackbar/info-snackbar.component';
+import { DragAndDropFilesDirective } from './drag-and-drop-files.directive';
 
 var appRoutes: Routes;
 
@@ -102,7 +103,8 @@ if(!environment.production){
     SuccessSnackbarComponent,
     WarnSnackbarComponent,
     ErrorSnackbarComponent,
-    InfoSnackbarComponent
+    InfoSnackbarComponent,
+    DragAndDropFilesDirective
   ],
   imports: [
     CdkTableModule,

--- a/src/app/drag-and-drop-files.directive.ts
+++ b/src/app/drag-and-drop-files.directive.ts
@@ -1,0 +1,64 @@
+import { Directive, HostBinding, HostListener, Output, EventEmitter } from '@angular/core';
+
+/** A directive to handle drag & drop actions
+ * Taken mostly from: https://medium.com/@tarekabdelkhalek/how-to-create-a-drag-and-drop-file-uploading-in-angular-78d9eba0b854
+ */
+@Directive({
+  selector: '[appDragAndDropFiles]'
+})
+export class DragAndDropFilesDirective {
+  /** Keep track of when user hovers over input with files */
+  @HostBinding('class.fileover') fileOver: boolean;
+
+  /** The actual files recently dragged & dropped */
+  @Output() fileDropped = new EventEmitter<any>();
+
+  /** Empty */
+  constructor() { }
+
+  // Listen for when user begins dragging over container
+  @HostListener('dragover', ['$event'])
+  public onDragOver(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.fileOver = true;
+  }
+
+  // Listen for when user stops dragging files over container
+  @HostListener('dragleave', ['$event'])
+  public onDragLeave(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.fileOver = false;
+  }
+
+  // Listen for dropped action
+  @HostListener('drop', ['$event'])
+  public onDrop(event) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.fileOver = false;
+
+    let isValid = true;
+
+    // Format a new $event object
+    let files = event.dataTransfer?.files as any;
+    let newEvent = {
+      target: {
+        files: files
+      }
+    };
+
+    // Validate that we received only .torrent files!
+    for(const file of files) {
+      if(!(file.name as string).endsWith('.torrent')) { isValid = false; break; }
+    }
+
+    if(isValid && files.length > 0) {
+      this.fileDropped.emit(newEvent);
+    }
+  }
+}

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -7,7 +7,7 @@
         <div class="file_upload_container">
           <br/>
 
-          <div class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event, true)" (click)="torrentFileUpload.click()">
+          <div [ngClass]="{'dark-theme': isDarkTheme | async}" class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event, true)" (click)="torrentFileUpload.click()">
             <!-- <h4>{{getFilesToUploadString()}}</h4> -->
 
             <h4>Drag and drop files here</h4>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -8,8 +8,6 @@
           <br/>
 
           <div [ngClass]="{'dark-theme': isDarkTheme | async}" class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event, true)" (click)="torrentFileUpload.click()">
-            <!-- <h4>{{getFilesToUploadString()}}</h4> -->
-
             <h4>Drag and drop files here</h4>
             <h4>or</h4>
 

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -16,7 +16,7 @@
               &nbsp; Browse for files
             </button>
 
-            <button *ngIf="hadUploadedFiles()" color="warn" mat-stroked-button (click)="clearUploadedFiles($event)" style="margin-top: 10px;">
+            <button *ngIf="hasUploadedFiles()" color="warn" mat-stroked-button (click)="clearUploadedFiles($event)" style="margin-top: 10px;">
               <mat-icon>close</mat-icon>
               Clear selection
             </button>
@@ -32,7 +32,10 @@
 
           <div *ngIf="show_torrent_contents">
             <h3> Torrent Contents </h3>
-            <mat-card-subtitle> Note: Choosing too many files may cause slow-downs. </mat-card-subtitle>
+            <mat-card-subtitle *ngIf="!hasUploadedFiles()">
+              <i> Try uploading some files first. </i>
+            </mat-card-subtitle>
+
             <div class="files_in_torrents">
               <app-file-system-tree-explorer
               [showProgress]="false"

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -4,33 +4,40 @@
   <mat-dialog-content class="mat-typography dialog_content">
     <mat-tab-group mat-align-tabs="start" (selectedTabChange)="handleTabChange($event)">
       <mat-tab label="File Upload">
-        <br/>
+        <div class="file_upload_container">
+          <br/>
 
-        <div class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event)" (click)="torrentFileUpload.click()">
-          <!-- <h4>{{getFilesToUploadString()}}</h4> -->
+          <div class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event, true)" (click)="torrentFileUpload.click()">
+            <!-- <h4>{{getFilesToUploadString()}}</h4> -->
 
-          <h4>Drag and drop files here</h4>
-          <h4>or</h4>
+            <h4>Drag and drop files here</h4>
+            <h4>or</h4>
 
-          <button color="accent" mat-flat-button>
-            <mat-icon>attach_file</mat-icon>
-            &nbsp; Browse for files
-          </button>
+            <button color="accent" mat-flat-button>
+              <mat-icon>attach_file</mat-icon>
+              &nbsp; Browse for files
+            </button>
 
-          <input multiple #torrentFileUpload type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
-        </div>
-        <br/>
+            <br/>
+            <h4 *ngIf="!show_torrent_contents">
+              <i> {{getFilesToUploadString()}} </i>
+            </h4>
 
-        <div *ngIf="show_torrent_contents">
-          <h3> Torrent Contents </h3>
-          <mat-card-subtitle> Note: Choosing too many files may cause slow-downs. </mat-card-subtitle>
-          <div class="files_in_torrents">
-            <app-file-system-tree-explorer
-            [showProgress]="false"
-            [directories]="serialized_nodes"> </app-file-system-tree-explorer>
+            <input multiple #torrentFileUpload type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
           </div>
           <br/>
-        </div>
+
+          <div *ngIf="show_torrent_contents">
+            <h3> Torrent Contents </h3>
+            <mat-card-subtitle> Note: Choosing too many files may cause slow-downs. </mat-card-subtitle>
+            <div class="files_in_torrents">
+              <app-file-system-tree-explorer
+              [showProgress]="false"
+              [directories]="serialized_nodes"> </app-file-system-tree-explorer>
+            </div>
+            <br/>
+          </div>
+      </div>
       </mat-tab>
 
       <mat-tab label="Magnet URL">

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -13,9 +13,14 @@
             <h4>Drag and drop files here</h4>
             <h4>or</h4>
 
-            <button color="accent" mat-flat-button>
+            <button color="primary" mat-flat-button>
               <mat-icon>attach_file</mat-icon>
               &nbsp; Browse for files
+            </button>
+
+            <button *ngIf="hadUploadedFiles()" color="warn" mat-stroked-button (click)="clearUploadedFiles($event)" style="margin-top: 10px;">
+              <mat-icon>close</mat-icon>
+              Clear selection
             </button>
 
             <br/>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.html
@@ -6,13 +6,16 @@
       <mat-tab label="File Upload">
         <br/>
 
-        <div class="upload_files">
-          <button color="accent" mat-raised-button (click)="torrentFileUpload.click()">
-            <mat-icon>attach_file</mat-icon>
-            &nbsp; Choose Files
-          </button>
+        <div class="upload_files" appDragAndDropFiles (fileDropped)="updateFiles($event)" (click)="torrentFileUpload.click()">
+          <!-- <h4>{{getFilesToUploadString()}}</h4> -->
 
-          <h4>{{getFilesToUploadString()}}</h4>
+          <h4>Drag and drop files here</h4>
+          <h4>or</h4>
+
+          <button color="accent" mat-flat-button>
+            <mat-icon>attach_file</mat-icon>
+            &nbsp; Browse for files
+          </button>
 
           <input multiple #torrentFileUpload type="file" accept=".torrent" id="torrentFileUpload" (change)="updateFiles($event)">
         </div>

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
@@ -65,7 +65,7 @@ mat-hint {
   align-self: center;
 
   width: 95%;
-  height: 200px;
+  min-height: 200px;
 
   padding: 5px;
   text-align: center;

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
@@ -50,6 +50,11 @@ mat-hint {
   display: none;
 }
 
+.file_upload_container {
+  display: flex;
+  flex-direction: column;
+}
+
 .upload_files {
   display: flex;
   flex-direction: column;
@@ -57,13 +62,20 @@ mat-hint {
   justify-content: center;
   align-items: center;
 
-  width: 400px;
+  align-self: center;
+
+  width: 95%;
   height: 200px;
 
   padding: 5px;
   text-align: center;
 
   border: dashed 1px grey;
+}
+
+.no_torrent_contents_msg {
+  align-self: center;
+  width: 95%;
 }
 
 .upload_files h4 {

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
@@ -64,13 +64,27 @@ mat-hint {
 
   align-self: center;
 
-  width: 95%;
+  width: 100%;
   min-height: 200px;
 
   padding: 5px;
   text-align: center;
 
+  /** Nice border */
   border: dashed 1px grey;
+  border-radius: 20px;
+
+  /** Styles to apply when hovering over drag & drop container */
+  &.fileover {
+    box-shadow: inset 0px 0px 60px -10px rgba(0, 0, 0, 0.2);
+    transition: all ease-in-out 200ms;
+  }
+
+  /** Styles to apply when hovering over drag & drop container */
+  &.dark-theme.fileover {
+    box-shadow: inset 0px 0px 60px -10px rgba(136, 136, 136, 1);
+    transition: all ease-in-out 200ms;
+  }
 }
 
 .no_torrent_contents_msg {

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.scss
@@ -52,8 +52,18 @@ mat-hint {
 
 .upload_files {
   display: flex;
-  flex-direction: row;
-  align-items: baseline;
+  flex-direction: column;
+
+  justify-content: center;
+  align-items: center;
+
+  width: 400px;
+  height: 200px;
+
+  padding: 5px;
+  text-align: center;
+
+  border: dashed 1px grey;
 }
 
 .upload_files h4 {

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -122,6 +122,19 @@ export class AddTorrentDialogComponent implements OnInit {
     this.parse_uploaded_files();
   }
 
+  /** Clear list of files user chose to upload */
+  clearUploadedFiles(e: any): void {
+    e.preventDefault();
+    e.stopPropagation();
+
+    this.filesToUpload = [];
+    this.parse_uploaded_files();
+  }
+
+  hadUploadedFiles(): boolean {
+    return this.filesToUpload?.length > 0;
+  }
+
   /** Whether the Upload button should be disabled or not */
   isUploadDisabled(): boolean {
     let destinationEmpty = this.filesDestination.trim() === "";

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -131,7 +131,7 @@ export class AddTorrentDialogComponent implements OnInit {
     this.parse_uploaded_files();
   }
 
-  hadUploadedFiles(): boolean {
+  hasUploadedFiles(): boolean {
     return this.filesToUpload?.length > 0;
   }
 

--- a/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
+++ b/src/app/modals/add-torrent-dialog/add-torrent-dialog.component.ts
@@ -105,10 +105,20 @@ export class AddTorrentDialogComponent implements OnInit {
   }
 
   /** Update which torrents the user wants to upload. */
-  updateFiles(event: any): void {
+  updateFiles(event: any, dragAndDrop?: boolean): void {
     this.isTreeExplorerReady = false;
 
-    this.filesToUpload = event.target.files;
+    if(event.target.files.length === 0) { return; }
+
+    // When using drag & drop, append instead of override
+    if(dragAndDrop) {
+      let existing = this.filesToUpload || []
+      this.filesToUpload = [...existing, ...event.target.files]
+    }
+    else {
+      this.filesToUpload = event.target.files;
+    }
+
     this.parse_uploaded_files();
   }
 
@@ -147,7 +157,9 @@ export class AddTorrentDialogComponent implements OnInit {
 
   public getFilesToUploadString(): string {
     let len = this.filesToUpload ? this.filesToUpload.length : 0;
-    return len === 1 ? `${len} file` : `${len} files`;
+    let root = len === 1 ? `${len} file` : `${len} files`;
+
+    return `${root} chosen`;
   }
 
   /** Handle opening file explorer dialog & handling any callbacks */

--- a/src/app/services/app/application-config.service.ts
+++ b/src/app/services/app/application-config.service.ts
@@ -141,7 +141,9 @@ export class ApplicationConfigService {
 
     // Deep merge the properties using lodash
     let existing_preferences = this.user_preferences?.web_ui_options || JSON.parse(localStorage.getItem('web_ui_options'))
-    let default_preferences = ApplicationDefaults.DEFAULT_WEB_UI_SETTINGS
+
+    /** Deep copy! User preferences are pretty small, so we can do this fairly efficiently */
+    let default_preferences = JSON.parse(JSON.stringify(ApplicationDefaults.DEFAULT_WEB_UI_SETTINGS))
 
     /** Do a deep merge, such that existing_preferences take precedence.
      * However, if a particular preference doens't exist, then the default


### PR DESCRIPTION
Add functionality to drag & drop torrent files in file upload modal. Can now use both this and the traditional methods for uploading. Also some styling improvements.

Resolves #69.

**Screenshot**
Note: That glow is only shown when hovering a file over the upload container!

![image](https://user-images.githubusercontent.com/45879053/100493197-cd5c3580-3102-11eb-8ece-6bde40d7f1e0.png)
